### PR TITLE
Fix npm start

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha -w --require babel-register",
-    "start": "babel src -d lib & node lib/index.js & exit 0"
+    "start": "babel src -d lib && node lib/index.js && exit 0"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
Для последовательного запуска надо использовать двойной амперсанд, иначе это запуск в фоне.